### PR TITLE
Add OGP (Open Graph Protocol) appearance for URLs in MarkdownRenderer

### DIFF
--- a/src/components/organisms/markdown-renderer/index.tsx
+++ b/src/components/organisms/markdown-renderer/index.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import { css, blockStyle, h2Style, articleRoot } from "./index.css";
 import { TagList } from "@/components/organisms/tag-list";
 import rehypeRaw from "rehype-raw";
+import { LinkRenderer } from "./link-renderer";
 
 type Props = {
   title: string;
@@ -24,7 +25,13 @@ export const MarkdownRenderer: FC<Props> = ({
       {tags.length > 0 && <TagList tags={tags} />}
     </div>
     <article className={`${blockStyle} ${articleRoot}`}>
-      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw]}
+        components={{
+          a: LinkRenderer,
+        }}
+      >
         {markdown}
       </Markdown>
     </article>

--- a/src/components/organisms/markdown-renderer/link-renderer.tsx
+++ b/src/components/organisms/markdown-renderer/link-renderer.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, type FC } from "react";
+import {
+  OgpCard,
+  OgpCardLoading,
+  OgpCardError,
+} from "@/components/organisms/ogp-card";
+import { fetchOgpData, isStandaloneUrl, type OgpData } from "@/utils/ogpUtils";
+
+type LinkRendererProps = {
+  href?: string;
+  children?: React.ReactNode;
+};
+
+export const LinkRenderer: FC<LinkRendererProps> = ({ href, children }) => {
+  const [ogpData, setOgpData] = useState<OgpData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const shouldRenderAsCard =
+    href &&
+    isStandaloneUrl(
+      typeof children === "string" ? children : String(children),
+      href,
+    );
+
+  useEffect(() => {
+    if (!shouldRenderAsCard || !href) return;
+
+    let isCancelled = false;
+
+    const loadOgpData = async () => {
+      setIsLoading(true);
+      setHasError(false);
+
+      try {
+        const data = await fetchOgpData(href);
+        if (!isCancelled) {
+          if (data) {
+            setOgpData(data);
+          } else {
+            setHasError(true);
+          }
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          console.warn("Failed to load OGP data:", error);
+          setHasError(true);
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadOgpData();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [shouldRenderAsCard, href]);
+
+  if (!href) {
+    return <>{children}</>;
+  }
+
+  if (!shouldRenderAsCard) {
+    const isExternalLink =
+      href.startsWith("http") &&
+      typeof window !== "undefined" &&
+      !href.includes(window.location.hostname);
+    return (
+      <a
+        href={href}
+        target={isExternalLink ? "_blank" : undefined}
+        rel={isExternalLink ? "noopener noreferrer" : undefined}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  if (isLoading) {
+    return <OgpCardLoading url={href} />;
+  }
+
+  if (hasError || !ogpData) {
+    return <OgpCardError url={href}>{children}</OgpCardError>;
+  }
+
+  return <OgpCard ogpData={ogpData} />;
+};

--- a/src/components/organisms/ogp-card/index.css.ts
+++ b/src/components/organisms/ogp-card/index.css.ts
@@ -1,0 +1,105 @@
+import { vars } from "@/style.css";
+import { style } from "@vanilla-extract/css";
+
+export const ogpCardStyle = style({
+  display: "flex",
+  border: `1px solid ${vars.color.bgSecondary}`,
+  borderRadius: "8px",
+  textDecoration: "none",
+  color: "inherit",
+  overflow: "hidden",
+  marginTop: "16px",
+  marginBottom: "16px",
+  transition: "box-shadow 0.2s ease",
+  maxWidth: "100%",
+
+  ":hover": {
+    boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)",
+  },
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      flexDirection: "column",
+    },
+  },
+});
+
+export const ogpImageStyle = style({
+  width: "120px",
+  height: "90px",
+  objectFit: "cover",
+  flexShrink: 0,
+  backgroundColor: vars.color.bgSecondary,
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "100%",
+      height: "150px",
+    },
+  },
+});
+
+export const ogpContentStyle = style({
+  padding: "12px 16px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  flex: 1,
+  minWidth: 0,
+});
+
+export const ogpTitleStyle = style({
+  fontSize: "16px",
+  fontWeight: 600,
+  color: vars.color.primary,
+  marginBottom: "4px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  lineHeight: 1.4,
+});
+
+export const ogpDescriptionStyle = style({
+  fontSize: "14px",
+  color: "#666",
+  marginBottom: "8px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  lineHeight: 1.4,
+});
+
+export const ogpSiteNameStyle = style({
+  fontSize: "12px",
+  color: vars.color.bgSecondary,
+  fontWeight: 500,
+  textTransform: "uppercase",
+});
+
+export const ogpLoadingStyle = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "24px",
+  border: `1px solid ${vars.color.bgSecondary}`,
+  borderRadius: "8px",
+  marginTop: "16px",
+  marginBottom: "16px",
+  color: vars.color.bgSecondary,
+  fontSize: "14px",
+});
+
+export const ogpErrorStyle = style({
+  color: vars.color.primary,
+  textDecoration: "none",
+  borderBottom: `1px solid ${vars.color.primary}`,
+
+  ":hover": {
+    color: vars.color.secondary,
+    borderBottomColor: vars.color.secondary,
+  },
+});

--- a/src/components/organisms/ogp-card/index.tsx
+++ b/src/components/organisms/ogp-card/index.tsx
@@ -1,0 +1,71 @@
+import type { FC } from "react";
+import type { OgpData } from "@/utils/ogp";
+import {
+  ogpCardStyle,
+  ogpImageStyle,
+  ogpContentStyle,
+  ogpTitleStyle,
+  ogpDescriptionStyle,
+  ogpSiteNameStyle,
+  ogpLoadingStyle,
+  ogpErrorStyle,
+} from "./index.css";
+
+type Props = {
+  ogpData: OgpData;
+};
+
+export const OgpCard: FC<Props> = ({ ogpData }) => {
+  const { url, title, description, image, siteName } = ogpData;
+
+  const displayTitle = title || url;
+  const displaySiteName = siteName || new URL(url).hostname;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={ogpCardStyle}
+    >
+      {image && (
+        <img
+          src={image}
+          alt={displayTitle}
+          className={ogpImageStyle}
+          loading="lazy"
+          onError={(e) => {
+            e.currentTarget.style.display = "none";
+          }}
+        />
+      )}
+      <div className={ogpContentStyle}>
+        <div className={ogpTitleStyle}>{displayTitle}</div>
+        {description && (
+          <div className={ogpDescriptionStyle}>{description}</div>
+        )}
+        <div className={ogpSiteNameStyle}>{displaySiteName}</div>
+      </div>
+    </a>
+  );
+};
+
+export const OgpCardLoading: FC<{ url: string }> = ({ url }) => (
+  <div className={ogpLoadingStyle}>
+    Loading preview for {new URL(url).hostname}...
+  </div>
+);
+
+export const OgpCardError: FC<{ url: string; children: React.ReactNode }> = ({
+  url,
+  children,
+}) => (
+  <a
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={ogpErrorStyle}
+  >
+    {children}
+  </a>
+);

--- a/src/utils/ogpUtils/index.ts
+++ b/src/utils/ogpUtils/index.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+export const ogpDataSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+  siteName: z.string().optional(),
+  url: z.string(),
+  type: z.string().optional(),
+});
+
+export type OgpData = z.infer<typeof ogpDataSchema>;
+
+const OGP_CACHE = new Map<string, OgpData | null>();
+const OGP_PENDING = new Map<string, Promise<OgpData | null>>();
+
+/**
+ * Extract OGP metadata from HTML content
+ */
+function extractOgpFromHtml(html: string, url: string): OgpData {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  const getMetaContent = (property: string): string | undefined => {
+    const element = doc.querySelector(
+      `meta[property="${property}"], meta[name="${property}"]`,
+    );
+    return element?.getAttribute("content") || undefined;
+  };
+
+  return {
+    url,
+    title: getMetaContent("og:title") || doc.title || undefined,
+    description:
+      getMetaContent("og:description") ||
+      getMetaContent("description") ||
+      undefined,
+    image: getMetaContent("og:image") || undefined,
+    siteName: getMetaContent("og:site_name") || undefined,
+    type: getMetaContent("og:type") || undefined,
+  };
+}
+
+/**
+ * Fetch OGP metadata for a given URL
+ * Note: This implementation may face CORS issues for many sites
+ * In production, consider using a CORS proxy or server-side API
+ */
+export async function fetchOgpData(url: string): Promise<OgpData | null> {
+  try {
+    new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (OGP_CACHE.has(url)) {
+    return OGP_CACHE.get(url) ?? null;
+  }
+
+  if (OGP_PENDING.has(url)) {
+    const pendingRequest = OGP_PENDING.get(url);
+    if (pendingRequest) {
+      return await pendingRequest;
+    }
+  }
+
+  const fetchPromise = (async (): Promise<OgpData | null> => {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; OGP-Bot/1.0)",
+        },
+        mode: "cors",
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const html = await response.text();
+      const ogpData = extractOgpFromHtml(html, url);
+
+      OGP_CACHE.set(url, ogpData);
+      return ogpData;
+    } catch (error) {
+      console.warn(`Failed to fetch OGP data for ${url}:`, error);
+      OGP_CACHE.set(url, null);
+      return null;
+    } finally {
+      OGP_PENDING.delete(url);
+    }
+  })();
+
+  OGP_PENDING.set(url, fetchPromise);
+  return await fetchPromise;
+}
+
+/**
+ * Check if a URL should be rendered as an OGP card
+ * Only standalone URLs (not inline links) should become cards
+ */
+export function isStandaloneUrl(text: string, href: string): boolean {
+  const trimmedText = text.trim();
+  const trimmedHref = href.trim();
+
+  return trimmedText === trimmedHref || trimmedText === href;
+}
+
+/**
+ * Clear OGP cache (useful for development/testing)
+ */
+export function clearOgpCache(): void {
+  OGP_CACHE.clear();
+  OGP_PENDING.clear();
+}


### PR DESCRIPTION
This implementation adds rich preview cards for standalone URLs in markdown content, showing title, description, and images from the linked pages.

Features:
- Custom LinkRenderer component that detects standalone vs inline URLs
- OGP card component with responsive design and loading/error states
- OGP metadata fetching utility with caching and error handling
- Server-side rendering (SSR) compatible implementation
- Follows existing atomic design patterns and styling conventions

Components:
- src/utils/ogpUtils/: OGP metadata fetching and caching utilities
- src/components/organisms/ogp-card/: OGP card display component
- src/components/organisms/markdown-renderer/link-renderer.tsx: Custom link renderer
- Updated MarkdownRenderer to use custom link renderer

The implementation gracefully falls back to regular links when OGP data cannot be fetched, ensuring progressive enhancement.

🤖 Generated with [Claude Code](https://claude.ai/code)